### PR TITLE
/header endpoint

### DIFF
--- a/env.go
+++ b/env.go
@@ -11,13 +11,25 @@ import (
 func handler(w http.ResponseWriter, req *http.Request) {
 	fmt.Printf("%+v\n", req)
 	fmt.Fprintln(w, strings.Join(os.Environ(), "\n"))
-	if req.URL.Path == "/crash" {
-		os.Exit(1)
+}
+
+func crashHandler(w http.ResponseWriter, req *http.Request) {
+	fmt.Fprintf(w, "Crashing...")
+	if flusher, ok := w.(http.Flusher); ok {
+		flusher.Flush()
 	}
+	os.Exit(1)
+}
+
+// headerHandler prints out the active headers in the request
+func headersHandler(w http.ResponseWriter, req *http.Request) {
+	req.Header.Write(w)
 }
 
 func main() {
 	http.HandleFunc("/", handler)
+	http.HandleFunc("/crash", crashHandler)
+	http.HandleFunc("/headers", headersHandler)
 	addr := ":" + os.Getenv("PORT")
 	fmt.Printf("Listening on %v\n", addr)
 	log.Fatal(http.ListenAndServe(addr, nil))

--- a/manifest.yml
+++ b/manifest.yml
@@ -2,6 +2,7 @@ applications:
 - name: go-env
   buildpack: https://github.com/cloudfoundry/go-buildpack#v1.7.0
   memory: 32M
+  disk_quota: 10M
   stackato:
     env:
       GOVERSION:


### PR DESCRIPTION
This adds a `/header` endpoint to show the HTTP request headers.

Also splits out how `/crash` is handled.
